### PR TITLE
Update documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scPCA
 Title: Sparse Contrastive Principal Component Analysis
-Version: 1.3.1
+Version: 1.3.2
 Authors@R: c(
     person(given = "Philippe",
            family = "Boileau",
@@ -21,8 +21,8 @@ Authors@R: c(
 Description: A toolbox for sparse contrastive principal component analysis
     (scPCA) of high-dimensional biological data. scPCA combines the stability
     and interpretability of sparse PCA with contrastive PCA's ability to
-    disentangle biological signal from techical noise through the use of control
-    data. Also implements and extends cPCA.
+    disentangle biological signal from unwanted variation through the use of
+    control data. Also implements and extends cPCA.
 Depends: R (>= 3.6)
 Imports:
     stats,
@@ -58,7 +58,7 @@ BugReports: https://github.com/PhilBoileau/scPCA/issues
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 RdMacros: Rdpack
 biocViews:
     PrincipalComponent,

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,3 +25,7 @@
 
 # Changes in version 1.1.15 (2020-06-02)
 + Fixing travis CI settings
+
+# Changes in version 1.3.2 (2020-08-05)
++ Updated scPCA function documentation
++ Corrected pelling mistakes

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,11 +38,12 @@ __Authors:__ [Philippe Boileau](https://pboileau.ca/),
 The exploration and analysis of modern high-dimensional biological data
 regularly involves the use of dimension reduction techniques in order to tease
 out meaningful and interpretable information from complex experimental data,
-often subject to batch effects and other technical noise. In tandem with the
+often subject to batch effects and other noise. In tandem with the
 development of sequencing technology (e.g., RNA-seq, scRNA-seq), many variants
 of PCA have been developed in attempts to remedy deficiencies in
-interpretability and stability that plague the original method. Such
-developments have included both various forms of sparse PCA (SPCA)
+interpretability and stability that plague vanila PCA.
+
+Such developments have included both various forms of sparse PCA (SPCA)
 [@zou2006sparse; @erichson2018sparse], which increase the stability and
 interpretability of principal component loadings in high dimensions, and, more
 recently, contrastive PCA (cPCA) [@abid2018exploring], which captures relevant
@@ -51,10 +52,9 @@ through comparison to a so-called background data set. While SPCA and cPCA have
 both individually proven useful in resolving distinct shortcomings of PCA,
 neither is capable of simultaneously tackling the issues of interpretability,
 stability and relevance simultaneously. The `scPCA` package implements
-_sparse constrastive PCA_ to accomplish these tasks in the context of
-high-dimensional biological data. In addition to implementing this newly
-developed technique, the `scPCA` package implements cPCA and
-generalizations thereof.
+_sparse constrastive PCA_ [@boileau2020] to accomplish these tasks in the context
+of high-dimensional biological data. In addition to implementing this newly developed 
+technique, the `scPCA` package implements cPCA and generalizations thereof.
 
 ---
 
@@ -121,14 +121,6 @@ package. Please also make sure to cite the appropriate articles
 describing the statistical methodology.
 
 ```
-@manual{boileau2020scPCAbioc,
-  title = {{scPCA}: Sparse contrastive principal component analysis},
-  author = {Philippe  Boileau and Nima S Hejazi and Sandrine Dudoit},
-  year = {2020},
-  note = {R package version 1.1.9},
-  url = {https://bioconductor.org/scPCA},
-}
-
 @article{boileau2020scPCAjoss,
   doi = {10.21105/joss.02079},
   url = {https://doi.org/10.21105/joss.02079},
@@ -140,6 +132,14 @@ describing the statistical methodology.
   author = {Philippe Boileau and Nima Hejazi and Sandrine Dudoit},
   title = {scPCA: A toolbox for sparse contrastive principal component analysis in R},
   journal = {Journal of Open Source Software}
+}
+
+@manual{boileau2020scPCAbioc,
+  title = {{scPCA}: Sparse contrastive principal component analysis},
+  author = {Philippe  Boileau and Nima S Hejazi and Sandrine Dudoit},
+  year = {2020},
+  note = {R package version 1.1.9},
+  url = {https://bioconductor.org/scPCA},
 }
 
 @article{boileau2020scPCA,

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,7 +41,7 @@ out meaningful and interpretable information from complex experimental data,
 often subject to batch effects and other noise. In tandem with the
 development of sequencing technology (e.g., RNA-seq, scRNA-seq), many variants
 of PCA have been developed in attempts to remedy deficiencies in
-interpretability and stability that plague vanila PCA.
+interpretability and stability that plague vanilla PCA.
 
 Such developments have included both various forms of sparse PCA (SPCA)
 [@zou2006sparse; @erichson2018sparse], which increase the stability and
@@ -52,7 +52,7 @@ through comparison to a so-called background data set. While SPCA and cPCA have
 both individually proven useful in resolving distinct shortcomings of PCA,
 neither is capable of simultaneously tackling the issues of interpretability,
 stability and relevance simultaneously. The `scPCA` package implements
-_sparse constrastive PCA_ [@boileau2020] to accomplish these tasks in the context
+_sparse contrastive PCA_ [@boileau2020] to accomplish these tasks in the context
 of high-dimensional biological data. In addition to implementing this newly developed 
 technique, the `scPCA` package implements cPCA and generalizations thereof.
 

--- a/README.md
+++ b/README.md
@@ -34,24 +34,27 @@ Dudoit](https://statistics.berkeley.edu/~sandrine/)
 The exploration and analysis of modern high-dimensional biological data
 regularly involves the use of dimension reduction techniques in order to
 tease out meaningful and interpretable information from complex
-experimental data, often subject to batch effects and other technical
-noise. In tandem with the development of sequencing technology (e.g.,
-RNA-seq, scRNA-seq), many variants of PCA have been developed in
-attempts to remedy deficiencies in interpretability and stability that
-plague the original method. Such developments have included both various
-forms of sparse PCA (SPCA) (Zou, Hastie, and Tibshirani 2006; Erichson
-et al. 2018), which increase the stability and interpretability of
-principal component loadings in high dimensions, and, more recently,
-contrastive PCA (cPCA) (Abid et al. 2018), which captures relevant
-information in the target (experimental) data set by eliminating
-technical noise through comparison to a so-called background data set.
-While SPCA and cPCA have both individually proven useful in resolving
-distinct shortcomings of PCA, neither is capable of simultaneously
-tackling the issues of interpretability, stability and relevance
-simultaneously. The `scPCA` package implements *sparse constrastive PCA*
-to accomplish these tasks in the context of high-dimensional biological
-data. In addition to implementing this newly developed technique, the
-`scPCA` package implements cPCA and generalizations thereof.
+experimental data, often subject to batch effects and other noise. In
+tandem with the development of sequencing technology (e.g., RNA-seq,
+scRNA-seq), many variants of PCA have been developed in attempts to
+remedy deficiencies in interpretability and stability that plague vanila
+PCA.
+
+Such developments have included both various forms of sparse PCA (SPCA)
+(Zou, Hastie, and Tibshirani 2006; Erichson et al. 2018), which increase
+the stability and interpretability of principal component loadings in
+high dimensions, and, more recently, contrastive PCA (cPCA) (Abid et al.
+2018), which captures relevant information in the target (experimental)
+data set by eliminating technical noise through comparison to a
+so-called background data set. While SPCA and cPCA have both
+individually proven useful in resolving distinct shortcomings of PCA,
+neither is capable of simultaneously tackling the issues of
+interpretability, stability and relevance simultaneously. The `scPCA`
+package implements *sparse constrastive PCA* (Boileau, Hejazi, and
+Dudoit 2020) to accomplish these tasks in the context of
+high-dimensional biological data. In addition to implementing this newly
+developed technique, the `scPCA` package implements cPCA and
+generalizations thereof.
 
 -----
 
@@ -118,14 +121,6 @@ Please cite the first paper below after using the `scPCA` R software
 package. Please also make sure to cite the appropriate articles
 describing the statistical methodology.
 
-    @manual{boileau2020scPCAbioc,
-      title = {{scPCA}: Sparse contrastive principal component analysis},
-      author = {Philippe  Boileau and Nima S Hejazi and Sandrine Dudoit},
-      year = {2020},
-      note = {R package version 1.1.9},
-      url = {https://bioconductor.org/scPCA},
-    }
-    
     @article{boileau2020scPCAjoss,
       doi = {10.21105/joss.02079},
       url = {https://doi.org/10.21105/joss.02079},
@@ -137,6 +132,14 @@ describing the statistical methodology.
       author = {Philippe Boileau and Nima Hejazi and Sandrine Dudoit},
       title = {scPCA: A toolbox for sparse contrastive principal component analysis in R},
       journal = {Journal of Open Source Software}
+    }
+    
+    @manual{boileau2020scPCAbioc,
+      title = {{scPCA}: Sparse contrastive principal component analysis},
+      author = {Philippe  Boileau and Nima S Hejazi and Sandrine Dudoit},
+      year = {2020},
+      note = {R package version 1.1.9},
+      url = {https://bioconductor.org/scPCA},
     }
     
     @article{boileau2020scPCA,
@@ -172,6 +175,15 @@ See file `LICENSE` for details.
 Abid, Abubakar, Martin J Zhang, Vivek K Bagaria, and James Zou. 2018.
 “Exploring Patterns Enriched in a Dataset with Contrastive Principal
 Component Analysis.” *Nature Communications* 9 (1): 2134.
+
+</div>
+
+<div id="ref-boileau2020">
+
+Boileau, Philippe, Nima S Hejazi, and Sandrine Dudoit. 2020. “Exploring
+High-Dimensional Biological Data with Sparse Contrastive Principal
+Component Analysis.” *Bioinformatics*, March.
+<https://doi.org/10.1093/bioinformatics/btaa176>.
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ tease out meaningful and interpretable information from complex
 experimental data, often subject to batch effects and other noise. In
 tandem with the development of sequencing technology (e.g., RNA-seq,
 scRNA-seq), many variants of PCA have been developed in attempts to
-remedy deficiencies in interpretability and stability that plague vanila
-PCA.
+remedy deficiencies in interpretability and stability that plague
+vanilla PCA.
 
 Such developments have included both various forms of sparse PCA (SPCA)
 (Zou, Hastie, and Tibshirani 2006; Erichson et al. 2018), which increase
@@ -50,11 +50,11 @@ so-called background data set. While SPCA and cPCA have both
 individually proven useful in resolving distinct shortcomings of PCA,
 neither is capable of simultaneously tackling the issues of
 interpretability, stability and relevance simultaneously. The `scPCA`
-package implements *sparse constrastive PCA* (Boileau, Hejazi, and
-Dudoit 2020) to accomplish these tasks in the context of
-high-dimensional biological data. In addition to implementing this newly
-developed technique, the `scPCA` package implements cPCA and
-generalizations thereof.
+package implements *sparse contrastive PCA* (Boileau, Hejazi, and Dudoit
+2020) to accomplish these tasks in the context of high-dimensional
+biological data. In addition to implementing this newly developed
+technique, the `scPCA` package implements cPCA and generalizations
+thereof.
 
 -----
 

--- a/man/cvSelectParams.Rd
+++ b/man/cvSelectParams.Rd
@@ -45,7 +45,7 @@ two such eigenvectors.}
 
 \item{alg}{A \code{character} indicating the SPCA algorithm used to sparsify
 the contrastive loadings. Currently supports \code{iterative} for the
-\insertRef{zou2006sparse}{scPCA} implemententation, \code{var_proj} for the
+\insertRef{zou2006sparse}{scPCA} implementation, \code{var_proj} for the
 non-randomized \insertRef{erichson2018sparse}{scPCA} solution, and
 \code{rand_var_proj} for the randomized
 \insertRef{erichson2018sparse}{scPCA} result.}
@@ -58,7 +58,7 @@ logarithmically spaced values between 0.1 and 1000.}
 loadings. The default is to use 20 equidistant values between 0.05 and 1.}
 
 \item{clust_method}{A \code{character} specifying the clustering method to
-use for choosing the optimal constrastive parameter. Currently, this is
+use for choosing the optimal contrastive parameter. Currently, this is
 limited to either k-means, partitioning around medoids (PAM), and
 hierarchical clustering. The default is k-means clustering.}
 

--- a/man/scPCA.Rd
+++ b/man/scPCA.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/scPCA.R
 \name{scPCA}
 \alias{scPCA}
-\title{Sparse Constrastive Principal Component Analysis}
+\title{Sparse Contrastive Principal Component Analysis}
 \usage{
 scPCA(
   target,
@@ -27,51 +27,52 @@ scPCA(
 as a \code{data.frame} or \code{matrix}.}
 
 \item{background}{The background data set, in a standard format such as a
-\code{data.frame} or \code{matrix}. Note that the number of features must
-match the number of features in the target data.}
+\code{data.frame} or \code{matrix}. The features must match the features of
+the target data set.}
 
 \item{center}{A \code{logical} indicating whether the target and background
-data sets should be centered to mean zero.}
+data sets' features should be centered to mean zero.}
 
 \item{scale}{A \code{logical} indicating whether the target and background
-data sets should be scaled to unit variance.}
+data sets' features should be scaled to unit variance.}
 
 \item{n_eigen}{A \code{numeric} indicating the number of eigenvectors (or
-sparse contrastive components) to be computed. The default is to compute
-two such eigenvectors.}
+(sparse) contrastive components) to be computed. Two eigenvectors are
+computed by default.}
 
 \item{cv}{A \code{numeric} indicating the number of cross-validation folds
 to use in choosing the optimal contrastive and penalization parameters from
 over the grids of \code{contrasts} and \code{penalties}. Cross-validation
 is expected to improve the robustness and generalization of the choice of
-these parameters; however, it increases the time the procedure costs, thus,
-the default is \code{NULL}, corresponding to no cross-validation.}
+these parameters. However, it increases the time the procedure costs.
+The default is therefore \code{NULL}, corresponding to no cross-validation.}
 
-\item{alg}{A \code{character} indicating the SPCA algorithm used to sparsify
-the contrastive loadings. Currently supports \code{iterative} for the
-\insertRef{zou2006sparse}{scPCA} implemententation, \code{var_proj} for the
-non-randomized \insertRef{erichson2018sparse}{scPCA} solution, and
-\code{rand_var_proj} for the randomized
-\insertRef{erichson2018sparse}{scPCA} result. Defaults to \code{iterative}.}
+\item{alg}{A \code{character} indicating the sparse PCA algorithm used to
+sparsify the contrastive loadings. Currently supports \code{iterative} for
+the \insertRef{zou2006sparse}{scPCA} implementation, \code{var_proj} for
+the non-randomized \insertRef{erichson2018sparse}{scPCA} solution, and
+\code{rand_var_proj} for the randomized \insertRef{erichson2018sparse}{scPCA}
+implementation. Defaults to \code{iterative}.}
 
 \item{contrasts}{A \code{numeric} vector of the contrastive parameters. Each
-element must be a unique non-negative real number. The default is to use 40
-logarithmically spaced values between 0.1 and 1000.}
+element must be a unique, non-negative real number. By default, 40
+logarithmically spaced values between 0.1 and 1000 are used.}
 
 \item{penalties}{A \code{numeric} vector of the L1 penalty terms on the
 loadings. The default is to use 20 equidistant values between 0.05 and 1.}
 
 \item{clust_method}{A \code{character} specifying the clustering method to
-use for choosing the optimal constrastive parameter. Currently, this is
+use for choosing the optimal contrastive parameter. Currently, this is
 limited to either k-means, partitioning around medoids (PAM), and
 hierarchical clustering. The default is k-means clustering.}
 
 \item{n_centers}{A \code{numeric} giving the number of centers to use in the
-clustering algorithm. If set to 1, cPCA, as first proposed by Abid et al.,
-is performed, regardless of what the \code{penalties} argument is set to.}
+clustering algorithm. If set to 1, cPCA, as first proposed by
+\insertRef{erichson2018sparse}{scPCA}, is performed, regardless of what the
+\code{penalties} argument is set to.}
 
 \item{max_iter}{A \code{numeric} giving the maximum number of iterations to
-be used in k-means clustering, defaulting to 10.}
+be used in k-means clustering. Defaults to 10.}
 
 \item{linkage_method}{A \code{character} specifying the agglomerative
 linkage method to be used if \code{clust_method = "hclust"}. The options
@@ -89,23 +90,34 @@ processing via the \pkg{BiocParallel} infrastructure. The default is
 \value{
 A list containing the following components:
   \itemize{
-    \item rotation - the matrix of variable loadings
-    \item x - the rotated data, centred and scaled if requested, multiplied
-      by the rotation matrix
-    \item contrast - the optimal contrastive parameter
-    \item penalty - the optimal L1 penalty term
-    \item center - whether the target dataset was centered
-    \item scale - whether the target dataset was scaled
+    \item \code{rotation}: The matrix of variable loadings if \code{n_centers}
+      is larger than one. Otherwise, a list of rotation matrices is returned,
+      one for each medoid. The number of medoids is specified by
+      \code{n_medoids}.
+    \item \code{x}: The rotated data, centred and scaled if requested,
+      multiplied by the rotation matrix if \code{n_centers} is larger than
+      one. Otherwise, a list of rotated data matrices is returned, one for
+      each medoid. The number of medoids is specified by \code{n_medoids}.
+    \item contrast: The optimal contrastive parameter.
+    \item penalty: The optimal L1 penalty term.
+    \item center: A logical indicating whether the target dataset was centered.
+    \item scale: A logical indicating whether the target dataset was scaled.
   }
 }
 \description{
 Given target and background data frames or matrices,
  \code{scPCA} will perform the sparse contrastive principal component
  analysis (scPCA) of the target data for a given number of eigenvectors, a
- vector of real-valued contrast parameters and a vector of penalty terms.
- For more information on the contrastive PCA method, consult
- \insertRef{abid2018exploring}{scPCA}. Sparse PCA is performed via the
- method of \insertRef{zou2006sparse}{scPCA}.
+ vector of real-valued contrast parameters, and a vector of sparsity inducing
+ penalty terms.
+ 
+ If instead you wish to perform contrastive principal component analysis
+ (cPCA), set the \code{penalties} argument to \code{0}. So long as the
+ \code{n_centers} parameter is larger than one, the automated hyperparameter
+ tuning heuristic described in \insertRef{boileau2020}{scPCA} is used.
+ Otherwise, the semi-automated approach of
+ \insertRef{abid2018exploring}{scPCA} is used to select the appropriate
+ hyperparameter.
 }
 \examples{
 # perform cPCA on the simulated data set

--- a/man/selectParams.Rd
+++ b/man/selectParams.Rd
@@ -41,7 +41,7 @@ two such eigenvectors.}
 
 \item{alg}{A \code{character} indicating the SPCA algorithm used to sparsify
 the contrastive loadings. Currently supports \code{iterative} for the
-\insertRef{zou2006sparse}{scPCA} implemententation, \code{var_proj} for the
+\insertRef{zou2006sparse}{scPCA} implementation, \code{var_proj} for the
 non-randomized \insertRef{erichson2018sparse}{scPCA} solution, and
 \code{rand_var_proj} for the randomized
 \insertRef{erichson2018sparse}{scPCA} result.}
@@ -54,7 +54,7 @@ logarithmically spaced values between 0.1 and 1000.}
 loadings. The default is to use 20 equidistant values between 0.05 and 1.}
 
 \item{clust_method}{A \code{character} specifying the clustering method to
-use for choosing the optimal constrastive parameter. Currently, this is
+use for choosing the optimal contrastive parameter. Currently, this is
 limited to either k-means, partitioning around medoids (PAM), and
 hierarchical clustering. The default is k-means clustering.}
 

--- a/vignettes/scpca_intro.Rmd
+++ b/vignettes/scpca_intro.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 Data pre-processing and exploratory data analysis and are two important steps in
 the data science life-cycle. As datasets become larger and the signal weaker,
-their importance increases. Thus, methods that are capable of extracting the
+their importance increases. Methods capable of extracting the
 signal from such datasets is badly needed. Often, these steps rely on
 dimensionality reduction techniques to isolate pertinent information in data.
 However, many of the most commonly-used methods fail to reduce the dimensions of
@@ -27,13 +27,13 @@ these large and noisy datasets successfully.
 
 Principal component analysis (PCA) is one such method. Although popular for its
 interpretable results and ease of implementation, PCA's performance on
-high-dimensional often leaves much to be desired. Its results on these large
+high-dimensional data often leaves much to be desired. Its results on these large
 datasets have been found to be unstable, and it is often unable to identify
 variation that is contextually meaningful.
 
-Fortunately, modifications of PCA have been developed to remedy these issues.
+Modifications of PCA have been developed to remedy these issues.
 Namely, sparse PCA (sPCA) was created to increase the stability of the principal
-component loadings and variable scores in high dimensions, and constrastive PCA
+component loadings and variable scores in high dimensions, and contrastive PCA
 (cPCA) was proposed as a method for capturing relevant information in the
 high-dimensional data by harnessing variation in control data
 [@abid2018exploring].
@@ -41,9 +41,9 @@ high-dimensional data by harnessing variation in control data
 Although sPCA and cPCA have proven useful in resolving individual shortcomings
 of PCA, neither is capable of tackling the issues of stability and relevance
 simultaneously. The `scPCA` package implements a combination of these methods,
-dubbed sparse constrastive PCA (scPCA) [@boileau2020], which draws on cPCA to
+dubbed sparse contrastive PCA (scPCA) [@boileau2020], which draws on cPCA to
 remove technical effects and on SPCA for sparsification of the loadings, thereby
-extracting stable, interpretable, and relevant uncontaminated signal from
+extracting stable, interpretable, and relevant signal from
 high-dimensional biological data. cPCA, previously unavailable to `R` users, is
 also implemented.
 
@@ -277,10 +277,8 @@ clustering-based hyperparameter tuning framework (detailed in [@boileau2020]).
 If the discovery of non-generalizable patterns in the data becomes a concern, a
 cross-validated approach to this tuning framework is made available. Below, we
 provide the results of the cPCA and scPCA algorithms whose hyperparemeters were
-selected using 3-fold cross-validation. We recommend using 5-fold
-cross-validation for larger datasets when using this framework, though the
-number of folds can vary with dataset size. Generally, smaller samples require
-fewer folds.
+selected using 3-fold cross-validation. We recommend using more folds for
+larger datasets when using this heuristic.
 
 ```{r cPCA_sim_cv}
 cpca_cv_sim <- scPCA(target = toy_df[, 1:30],
@@ -370,9 +368,9 @@ autoplot(timing_scPCA, log = TRUE) +
 
 The computational advantage of @erichson2018sparse's methods is clear. On larger
 datasets, the scPCA method relying on the randomized version of SPCA is
-demonstrably more efficient than its non-randomized counterparts, as well as
-other commonly-used dimensionality reduction techniques like t-Distributed
-Stochastic Neighbor Embedding [@vanDerMaaten2008][@boileau2020]. 
+demonstrably more efficient than its non-randomized counterparts [@boileau2020],
+as well as other commonly-used dimensionality reduction techniques like
+t-Distributed Stochastic Neighbor Embedding [@vanDerMaaten2008]. 
 
 ---
 
@@ -578,7 +576,7 @@ standard analysis of genomic data, use of this parallelization will be crucial,
 thus, each of the core subroutines of `scPCA` has an equivalent parallelized
 variant that makes use of the infrastructure provided by the [`BiocParallel`
 package](https://bioconductor.org/packages/BiocParallel). In order to make
-effective use of this paralleization, one need only set `parallel = TRUE` in a
+effective use of this parallelization, one need only set `parallel = TRUE` in a
 call to `scPCA` after having registered a particular parallelization back-end
 for parallel evaluation as described in the `BiocParallel` documentation. An
 example of this form of parallelization follows:


### PR DESCRIPTION
In response to https://github.com/PhilBoileau/scPCA/issues/45. Updated documentation of `scPCA` function:
- added paragraph in description explaining how to apply cPCA instead of scPCA
- cleared up argument definitions relating cPCA
- added details for expected output when running cPCA

Also included miscellaneous documentation updates to the README and vignette.